### PR TITLE
Retarget conda install from Anaconda to Intel

### DIFF
--- a/docs/install/experimental/install_for_gpu_conda.md
+++ b/docs/install/experimental/install_for_gpu_conda.md
@@ -25,7 +25,7 @@ You may need to update your conda first, as at least conda 4.1.11 is required.
 conda update conda
 
 #Take Intel Python 2023.2.0 as an example to conda environment, but generic Python is also recommended.
-conda create -n itex -c intel intelpython3_full==2023.2.0 python=3.9
+conda create -n itex -c https://software.repos.intel.com/python/conda/ intelpython3_full==2023.2.0 python=3.9
 ```
 
 Activate the environment by the following commands.


### PR DESCRIPTION
The Anaconda license has expired. The package is now on the Intel repository. I changed the install command to point to the Intel repository. Rodriguo Bernal Castro verified the command line is correct.